### PR TITLE
fix: delete useless datadog call

### DIFF
--- a/slo_generator/backends/datadog.py
+++ b/slo_generator/backends/datadog.py
@@ -124,8 +124,6 @@ class DatadogBackend:
         """
         slo_id = slo_config["spec"]["service_level_indicator"]["slo_id"]
         from_ts = timestamp - window
-        slo_data = self.client.ServiceLevelObjective.get(id=slo_id)
-        LOGGER.debug(f"SLO data: {slo_id} | Result: {pprint.pformat(slo_data)}")
         data = self.client.ServiceLevelObjective.history(
             id=slo_id,
             from_ts=from_ts,


### PR DESCRIPTION
200k+ call à l'api /slo/ par jour alors que les données ne sont pas réutilisées